### PR TITLE
Do not try to determine version from git tags

### DIFF
--- a/tools/read-version
+++ b/tools/read-version
@@ -65,7 +65,12 @@ output_json = '--json' in sys.argv
 src_version = ci_version.version_string()
 version_long = None
 
-if is_gitdir(_tdir) and which("git"):
+# Delphix: we set our own version
+# pylint: disable=w0125
+if True:
+    version = src_version
+    version_long = None
+elif is_gitdir(_tdir) and which("git"):
     flags = []
     if use_tags:
         flags = ['--tags']


### PR DESCRIPTION
When cloud-init is being built from a git repository, it tries to automatically determine the version of cloud-init by reading git tags. We do not provide those git tags so this code fails ungracefully. We bypass the git-specific code so that the version embedded in the code is used instead.