### PR TITLE
Add configuration to allow disabling public keys and user-data

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -182,8 +182,19 @@ def handle(_name, cfg, cloud, log, _args):
         disable_root = util.get_cfg_option_bool(cfg, "disable_root", True)
         disable_root_opts = util.get_cfg_option_str(cfg, "disable_root_opts",
                                                     ssh_util.DISABLE_USER_OPTS)
+        if 'allow_public_ssh_keys' in cfg:
+            allow_public_ssh_keys = cfg['allow_public_ssh_keys']
+        else:
+            allow_public_ssh_keys = True
 
-        keys = cloud.get_public_ssh_keys() or []
+        if allow_public_ssh_keys:
+            log.debug('allow_public_ssh_keys = True: Public ssh keys consumed')
+            keys = cloud.get_public_ssh_keys() or []
+        else:
+            log.debug('allow_public_ssh_keys = False: Public ssh keys '
+                      'discarded')
+            keys = []
+
         if "ssh_authorized_keys" in cfg:
             cfgkeys = cfg["ssh_authorized_keys"]
             keys.extend(cfgkeys)

--- a/cloudinit/config/tests/test_ssh.py
+++ b/cloudinit/config/tests/test_ssh.py
@@ -4,6 +4,9 @@
 from cloudinit.config import cc_ssh
 from cloudinit import ssh_util
 from cloudinit.tests.helpers import CiTestCase, mock
+import logging
+
+LOG = logging.getLogger(__name__)
 
 MODPATH = "cloudinit.config.cc_ssh."
 
@@ -66,7 +69,7 @@ class TestHandleSsh(CiTestCase):
         m_nug.return_value = ([], {})
         cloud = self.tmp_cloud(
             distro='ubuntu', metadata={'public-keys': keys})
-        cc_ssh.handle("name", cfg, cloud, None, None)
+        cc_ssh.handle("name", cfg, cloud, LOG, None)
         options = ssh_util.DISABLE_USER_OPTS.replace("$USER", "NONE")
         options = options.replace("$DISABLE_USER", "root")
         m_glob.assert_called_once_with('/etc/ssh/ssh_host_*key*')
@@ -94,7 +97,7 @@ class TestHandleSsh(CiTestCase):
         m_nug.return_value = ({user: {"default": user}}, {})
         cloud = self.tmp_cloud(
             distro='ubuntu', metadata={'public-keys': keys})
-        cc_ssh.handle("name", cfg, cloud, None, None)
+        cc_ssh.handle("name", cfg, cloud, LOG, None)
 
         options = ssh_util.DISABLE_USER_OPTS.replace("$USER", user)
         options = options.replace("$DISABLE_USER", "root")
@@ -119,7 +122,7 @@ class TestHandleSsh(CiTestCase):
         m_nug.return_value = ({user: {"default": user}}, {})
         cloud = self.tmp_cloud(
             distro='ubuntu', metadata={'public-keys': keys})
-        cc_ssh.handle("name", cfg, cloud, None, None)
+        cc_ssh.handle("name", cfg, cloud, LOG, None)
 
         options = ssh_util.DISABLE_USER_OPTS.replace("$USER", user)
         options = options.replace("$DISABLE_USER", "root")
@@ -144,7 +147,7 @@ class TestHandleSsh(CiTestCase):
         cloud = self.tmp_cloud(
             distro='ubuntu', metadata={'public-keys': keys})
         cloud.get_public_ssh_keys = mock.Mock(return_value=keys)
-        cc_ssh.handle("name", cfg, cloud, None, None)
+        cc_ssh.handle("name", cfg, cloud, LOG, None)
 
         self.assertEqual([mock.call(set(keys), user),
                           mock.call(set(keys), "root", options="")],

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -548,7 +548,17 @@ class Init(object):
         with events.ReportEventStack("consume-user-data",
                                      "reading and applying user-data",
                                      parent=self.reporter):
-            self._consume_userdata(frequency)
+            cfg = self.cfg
+            if 'allow_userdata' in cfg:
+                allow_userdata = cfg['allow_userdata']
+            else:
+                allow_userdata = True
+
+            if allow_userdata:
+                LOG.debug('allow_userdata = True: consuming user-data')
+                self._consume_userdata(frequency)
+            else:
+                LOG.debug('allow_userdata = False: discarding user-data')
         with events.ReportEventStack("consume-vendor-data",
                                      "reading and applying vendor-data",
                                      parent=self.reporter):


### PR DESCRIPTION
Those new settings give us control over the ingestion of public ssh keys and user-data.
Note that we leave them enabled by default to make sure unit tests pass.

### Related changes
delphix-platform: https://github.com/delphix/delphix-platform/pull/81
appliance-build: https://github.com/delphix/appliance-build/pull/290

## TESTING
 - linux-pkg: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/50/
 - ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1075/