### PR TITLE
Remove "ssh" dependencies from systemd service file

### DIFF
--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -3,8 +3,6 @@
 Description=Initial cloud-init job (metadata service crawler)
 DefaultDependencies=no
 Wants=cloud-init-local.service
-Wants=sshd-keygen.service
-Wants=sshd.service
 After=cloud-init-local.service
 After=systemd-networkd-wait-online.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
@@ -20,8 +18,6 @@ Before=wicked.service
 After=dbus.service
 {% endif %}
 Before=network-online.target
-Before=sshd-keygen.service
-Before=sshd.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 Before=sysinit.target
 Conflicts=shutdown.target


### PR DESCRIPTION
Without this change, the "critical-chain" for the "ssh" service looks like this:
```
$ sudo systemd-analyze critical-chain ssh.service
The time after the unit is active or started is printed after the "@" character.
The time the unit takes to start is printed after the "+" character.

ssh.service +186ms
└─cloud-init.service @9.051s +24.879s
  └─systemd-networkd-wait-online.service @8.981s +68ms
    └─systemd-networkd.service @6.249s +2.727s
      └─network-pre.target @6.247s
        └─cloud-init-local.service @3.489s +2.755s
          └─open-vm-tools.service @3.486s
            └─vgauth.service @3.483s
              └─systemd-tmpfiles-setup.service @3.402s +70ms
                └─local-fs.target @3.393s
                  └─run-user-65433.mount @35.383s
                    └─local-fs-pre.target @1.418s
                      └─keyboard-setup.service @1.199s +216ms
                        └─systemd-journald.socket @1.148s
                          └─system.slice @1.136s
                            └─-.slice @912ms
```

With this change, it looks like this:
```
$ sudo systemd-analyze critical-chain ssh.service                                                                           
The time after the unit is active or started is printed after the "@" character.                                                              
The time the unit takes to start is printed after the "+" character.                                                                          
                                                                                                                                              
ssh.service +598ms                                                                                                                            
└─systemd-journald.socket @1.387s                                                                                 
  └─system.slice @1.375s                                                                                                                      
    └─-.slice @1.159s 
```

Additionally, in my tests above, I removed set `DefaultDependencies=no` in the "ssh" service definition, and also removed any `After=` lines from it.