### PR TITLE
Add "local-fs.target" dependency to "cloud-init.service"

### DIFF
--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -2,6 +2,7 @@
 [Unit]
 Description=Initial cloud-init job (metadata service crawler)
 DefaultDependencies=no
+After=local-fs.target
 Wants=cloud-init-local.service
 After=cloud-init-local.service
 After=systemd-networkd-wait-online.service


### PR DESCRIPTION
Since the cloud-init service may need to write to the local filesystem,
e.g. to insert ssh keys, it should wait for the "local-fs.target" to
complete before it runs.