### PR TITLE
update /etc/hosts template comments

### DIFF
--- a/templates/hosts.debian.tmpl
+++ b/templates/hosts.debian.tmpl
@@ -8,7 +8,9 @@ you need to add the following to config:
 # Your system has configured 'manage_etc_hosts' as True.
 # As a result, if you wish for changes to this file to persist
 # then you will need to either
-# a.) make changes to the master file in /etc/cloud/templates/hosts.debian.tmpl
+# a.) make changes to the master file in /etc/cloud/templates/hosts.debian.tmpl,
+#     then run "sudo cloud-init single --name update-etc-hosts" to update
+#     /etc/hosts
 # b.) change or remove the value of 'manage_etc_hosts' in
 #     /etc/cloud/cloud.cfg or cloud-config from user-data
 #

--- a/templates/hosts.freebsd.tmpl
+++ b/templates/hosts.freebsd.tmpl
@@ -8,7 +8,9 @@ you need to add the following to config:
 # Your system has configured 'manage_etc_hosts' as True.
 # As a result, if you wish for changes to this file to persist
 # then you will need to either
-# a.) make changes to the master file in /etc/cloud/templates/hosts.freebsd.tmpl
+# a.) make changes to the master file in /etc/cloud/templates/hosts.debian.tmpl,
+#     then run "sudo cloud-init single --name update-etc-hosts" to update
+#     /etc/hosts
 # b.) change or remove the value of 'manage_etc_hosts' in
 #     /etc/cloud/cloud.cfg or cloud-config from user-data
 # 

--- a/templates/hosts.redhat.tmpl
+++ b/templates/hosts.redhat.tmpl
@@ -8,7 +8,9 @@ you need to add the following to config:
 # Your system has configured 'manage_etc_hosts' as True.
 # As a result, if you wish for changes to this file to persist
 # then you will need to either
-# a.) make changes to the master file in /etc/cloud/templates/hosts.redhat.tmpl
+# a.) make changes to the master file in /etc/cloud/templates/hosts.debian.tmpl,
+#     then run "sudo cloud-init single --name update-etc-hosts" to update
+#     /etc/hosts
 # b.) change or remove the value of 'manage_etc_hosts' in
 #     /etc/cloud/cloud.cfg or cloud-config from user-data
 # 

--- a/templates/hosts.suse.tmpl
+++ b/templates/hosts.suse.tmpl
@@ -8,7 +8,9 @@ you need to add the following to config:
 # Your system has configured 'manage_etc_hosts' as True.
 # As a result, if you wish for changes to this file to persist
 # then you will need to either
-# a.) make changes to the master file in /etc/cloud/templates/hosts.suse.tmpl
+# a.) make changes to the master file in /etc/cloud/templates/hosts.debian.tmpl,
+#     then run "sudo cloud-init single --name update-etc-hosts" to update
+#     /etc/hosts
 # b.) change or remove the value of 'manage_etc_hosts' in
 #     /etc/cloud/cloud.cfg or cloud-config from user-data
 #


### PR DESCRIPTION
In case support sees the need to modify /etc/hosts, this will give them more information for how to do so in a persistent manner.

Currently this is the comment in `/etc/hosts`:
```
$ cat /etc/hosts
# Your system has configured 'manage_etc_hosts' as True.
# As a result, if you wish for changes to this file to persist
# then you will need to either
# a.) make changes to the master file in /etc/cloud/templates/hosts.debian.tmpl
# b.) change or remove the value of 'manage_etc_hosts' in
#     /etc/cloud/cloud.cfg or cloud-config from user-data
#
```
Currently we do not want to turn off `manage_etc_hosts` since it does useful work in the cloud. by adding the current hostname into `/etc/hosts`.

## Testing
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1290/