### PR TITLE
Disable cloud-init from running in upgrade container

### DIFF
--- a/systemd/cloud-init-generator.tmpl
+++ b/systemd/cloud-init-generator.tmpl
@@ -32,6 +32,12 @@ debug() {
     echo "$@" >> "$LOG"
 }
 
+disable_in_container() {
+    _RET="unset"
+    systemd-detect-virt --container --quiet && _RET="$DISABLE"
+    return 0
+}
+
 etc_file() {
     local pprefix="${1:-/etc/cloud/cloud-init.}"
     _RET="unset"
@@ -110,7 +116,7 @@ main() {
     debug 2 "$0 $*"
 
     local search result="error" ret=""
-    for search in kernel_cmdline etc_file default; do
+    for search in disable_in_container kernel_cmdline etc_file default; do
         if $search; then
             debug 1 "$search found $_RET"
             [ "$_RET" = "$ENABLE" -o "$_RET" = "$DISABLE" ] &&


### PR DESCRIPTION
The configuration done via cloud-init generally should not be needed for
the upgrade container, and it can actually cause problems if it races
with the upgrade logic. For example, we use cloud-init to configure the
APT sources on our "dev" images, and this can race with the upgrade
logic that also modifies the APT sources (to point to the APT repository
of our unpacked upgrade image). Thus, this change disables all of the
cloud-init related services from running within the upgrade container.