### PR TITLE
DLPX-70169 cloud-init and related services need override.conf to prevent them from running within upgrade container

### DIFF
--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -4,6 +4,7 @@ Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
 After=snapd.seeded.service
 Wants=network-online.target cloud-config.target
+ConditionalVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -7,6 +7,7 @@ After=multi-user.target
 Before=apt-daily.service
 {% endif %}
 Wants=network-online.target cloud-config.service
+ConditionalVirtualization=!container
 
 
 [Service]

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -14,6 +14,7 @@ Before=sysinit.target
 Conflicts=shutdown.target
 {% endif %}
 RequiresMountsFor=/var/lib/cloud
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -28,6 +28,7 @@ Conflicts=shutdown.target
 Conflicts=shutdown.target
 {% endif %}
 Before=systemd-user-sessions.service
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This is a continuation of 144e73fc0e32c968f6d1f4ed4669384c1c4763ed.

As described in 144e73f, we don't want the cloud-init related services
to run within an upgrade container. Unfortunately, that prior commit
does not ensure the services don't run, when there's another service
that depend on a cloud-init service. In our case, when running on GCP,
the "google-startup-scripts" services has a depdency on "cloud-final",

    $ systemctl cat google-startup-scripts | grep Wants
    Wants=cloud-final.service

causing the cloud-init service to run even though it should have
otherwise been disabled (due to the changes in 144e73f).

This change adds configuration to all of the cloud-init services such
that they won't run in the upgrade container; even if they're
inadvertently started due to a dependency, as was our case on GCP.