### PR TITLE
DLPX-70214 [Backport of DLPX-70169 to 6.0.3.0] cloud-init and related services need override.conf to prevent them from running within upgrade container

### DIFF
--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -4,6 +4,7 @@ Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
 After=snapd.seeded.service
 Wants=network-online.target cloud-config.target
+ConditionalVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -7,6 +7,7 @@ After=multi-user.target
 Before=apt-daily.service
 {% endif %}
 Wants=network-online.target cloud-config.service
+ConditionalVirtualization=!container
 
 
 [Service]

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -14,6 +14,7 @@ Before=sysinit.target
 Conflicts=shutdown.target
 {% endif %}
 RequiresMountsFor=/var/lib/cloud
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -28,6 +28,7 @@ Conflicts=shutdown.target
 Conflicts=shutdown.target
 {% endif %}
 Before=systemd-user-sessions.service
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This is a cherry-pick of 61f2f79274966a1b5cbe9c0e63afcf48d73b7e53.