### PR TITLE
Fix uses of "ConditionalVirtualization" (#17)

### DIFF
--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -4,7 +4,7 @@ Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
 After=snapd.seeded.service
 Wants=network-online.target cloud-config.target
-ConditionalVirtualization=!container
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -7,7 +7,7 @@ After=multi-user.target
 Before=apt-daily.service
 {% endif %}
 Wants=network-online.target cloud-config.service
-ConditionalVirtualization=!container
+ConditionVirtualization=!container
 
 
 [Service]


### PR DESCRIPTION
In commit 61f2f79 we added the field "ConditionalVirtualization" to a
couple of the systemd services, rather than "ConditionVirtualization".
As a result, we can see messages like the following via dmesg:

    [    7.593710] systemd[1]: /lib/systemd/system/cloud-final.service:7: Unknown lvalue 'ConditionalVirtualization' in section 'Unit'
    [    7.604843] systemd[1]: /lib/systemd/system/cloud-config.service:6: Unknown lvalue 'ConditionalVirtualization' in section 'Unit'

This commit fixes the situation, replacing "ConditionalVirtualization"
with "ConditionVirtualization".