### PR TITLE
Generate network config on first and subsequent boots

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -181,8 +181,8 @@ class DataSource(object):
     # A datasource which supports writing network config on each system boot
     # would call update_events['network'].add(EventType.BOOT).
 
-    # Default: generate network config on new instance id (first boot).
-    update_events = {'network': set([EventType.BOOT_NEW_INSTANCE])}
+    # Default: generate network config on first boot and subsequent boots.
+    update_events = {'network': set([EventType.BOOT_NEW_INSTANCE, EventType.BOOT])}
 
     # N-tuple listing default values for any metadata-related class
     # attributes cached on an instance by a process_data runs. These attribute


### PR DESCRIPTION
This change modifies when cloud-init will generate the network config
for the system, such that it will now be generated for the first boot
(which it previously did) and all subsequent boots (which is new). This
way, if the system's network hardware changes (e.g. the MAC address
changes), the network configuration for the system will automatically
adapt on the next boot.

Also note that for a DE, this only applies when using the default
cloud-init generated network configuration. Currently, the cloud-init
config is only used prior to the DE administrator performing any manual
network configuration via the API or CLI. After manual network changes
are made, the DE will no longer use the cloud-init network config, at
which point this change will no longer have any affect.