### PR TITLE
DLPX-69865 IP configuration is lost if a MAC address changes

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -455,12 +455,13 @@ def generate_fallback_config(blacklist_drivers=None, config_driver=None):
         # can't read any interfaces addresses (or there are none); give up
         return None
 
-    # netfail cannot use mac for matching, they have duplicate macs
-    if is_netfail_master(target_name):
-        match = {'name': target_name}
-    else:
-        match = {
-            'macaddress': read_sys_net_safe(target_name, 'address').lower()}
+    #
+    # Always match on the name, rather than the MAC address. This way,
+    # if the MAC address changes (which is possible VM environments),
+    # the network configuration will still apply.
+    #
+    match = {'name': target_name}
+
     cfg = {'dhcp4': True, 'set-name': target_name, 'match': match}
     if config_driver:
         driver = device_driver(target_name)

--- a/cloudinit/net/tests/test_init.py
+++ b/cloudinit/net/tests/test_init.py
@@ -254,7 +254,7 @@ class TestGenerateFallbackConfig(CiTestCase):
         mac = 'aa:bb:cc:aa:bb:cc'
         write_file(os.path.join(self.sysdir, 'eth1', 'address'), mac)
         expected = {
-            'ethernets': {'eth1': {'match': {'macaddress': mac},
+            'ethernets': {'eth1': {'match': {'name': 'eth1'},
                                    'dhcp4': True, 'set-name': 'eth1'}},
             'version': 2}
         self.assertEqual(expected, net.generate_fallback_config())
@@ -265,7 +265,7 @@ class TestGenerateFallbackConfig(CiTestCase):
         mac = 'aa:bb:cc:aa:bb:cc'
         write_file(os.path.join(self.sysdir, 'eth0', 'address'), mac)
         expected = {
-            'ethernets': {'eth0': {'match': {'macaddress': mac}, 'dhcp4': True,
+            'ethernets': {'eth0': {'match': {'name': 'eth0'}, 'dhcp4': True,
                                    'set-name': 'eth0'}},
             'version': 2}
         self.assertEqual(expected, net.generate_fallback_config())
@@ -276,7 +276,7 @@ class TestGenerateFallbackConfig(CiTestCase):
         write_file(os.path.join(self.sysdir, 'eth0', 'address'), mac)
         expected = {
             'ethernets': {
-                'eth0': {'dhcp4': True, 'match': {'macaddress': mac},
+                'eth0': {'dhcp4': True, 'match': {'name': 'eth0'},
                          'set-name': 'eth0'}},
             'version': 2}
         valid_operstates = ['dormant', 'down', 'lowerlayerdown', 'unknown']

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -2606,7 +2606,7 @@ class TestGenerateFallbackConfig(CiTestCase):
         network_cfg = net.generate_fallback_config(config_driver=True)
         expected = {
             'ethernets': {'eth0': {'dhcp4': True, 'set-name': 'eth0',
-                                   'match': {'macaddress': '00:11:22:33:44:55',
+                                   'match': {'name': 'eth0',
                                              'driver': 'hv_netsvc'}}},
             'version': 2}
         self.assertEqual(expected, network_cfg)
@@ -2665,14 +2665,7 @@ iface eth0 inet dhcp
         with open(os.path.join(render_dir, 'netrules')) as fh:
             contents = fh.read()
         print(contents)
-        expected_rule = [
-            'SUBSYSTEM=="net"',
-            'ACTION=="add"',
-            'DRIVERS=="hv_netsvc"',
-            'ATTR{address}=="00:11:22:33:44:55"',
-            'NAME="eth0"',
-        ]
-        self.assertEqual(", ".join(expected_rule) + '\n', contents.lstrip())
+        self.assertEqual('', contents.lstrip())
 
     @mock.patch("cloudinit.net.sys_dev_path")
     @mock.patch("cloudinit.net.read_sys_net")
@@ -2729,14 +2722,7 @@ iface eth1 inet dhcp
         with open(os.path.join(render_dir, 'netrules')) as fh:
             contents = fh.read()
         print(contents)
-        expected_rule = [
-            'SUBSYSTEM=="net"',
-            'ACTION=="add"',
-            'DRIVERS=="hv_netsvc"',
-            'ATTR{address}=="00:11:22:33:44:55"',
-            'NAME="eth1"',
-        ]
-        self.assertEqual(", ".join(expected_rule) + '\n', contents.lstrip())
+        self.assertEqual('', contents.lstrip())
 
     @mock.patch("cloudinit.util.get_cmdline")
     @mock.patch("cloudinit.util.udevadm_settle")
@@ -2893,7 +2879,6 @@ class TestRhelSysConfigRendering(CiTestCase):
 #
 BOOTPROTO=dhcp
 DEVICE=eth1000
-HWADDR=07-1c-c6-75-a4-be
 NM_CONTROLLED=no
 ONBOOT=yes
 TYPE=Ethernet
@@ -3498,7 +3483,6 @@ class TestOpenSuseSysConfigRendering(CiTestCase):
 # Created by cloud-init on instance boot automatically, do not edit.
 #
 BOOTPROTO=dhcp4
-LLADDR=07-1c-c6-75-a4-be
 STARTMODE=auto
 """.lstrip()
             self.assertEqual(expected_content, content)
@@ -3854,7 +3838,7 @@ network:
         eth1000:
             dhcp4: true
             match:
-                macaddress: 07-1c-c6-75-a4-be
+                name: eth1000
             set-name: eth1000
     version: 2
 """


### PR DESCRIPTION
To make the network configuration more resilient to changes of the MAC
address, this change modifies the netplan configuration generated by
cloud-init to no longer match on the MAC address. This way, if the MAC
address of a NIC changes (which can happen in VM environments), the
network configuration on the system should still work as before.