### PR TITLE
DLPX-69865 IP configuration is lost if a MAC address changes

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1361,9 +1361,8 @@ def parse_network_config(imds_metadata):
                             '{ip}/{prefix}'.format(
                                 ip=privateIp, prefix=netPrefix))
                 if dev_config:
-                    mac = ':'.join(re.findall(r'..', intf['macAddress']))
                     dev_config.update(
-                        {'match': {'macaddress': mac.lower()},
+                        {'match': {'name': nicname},
                          'set-name': nicname})
                     netconfig['ethernets'][nicname] = dev_config
             evt.description = "network config from imds"

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -754,7 +754,7 @@ def convert_ec2_metadata_network_config(
                 break
         dev_config = {'dhcp4': True,
                       'dhcp6': False,
-                      'match': {'macaddress': mac.lower()},
+                      'match': {'name': nic_name},
                       'set-name': nic_name}
         nic_metadata = macs_metadata.get(mac)
         if nic_metadata.get('ipv6s'):  # Any IPv6 addresses configured
@@ -772,7 +772,7 @@ def convert_ec2_metadata_network_config(
         dhcp_override = {'route-metric': nic_idx * 100}
         dev_config = {'dhcp4': True, 'dhcp4-overrides': dhcp_override,
                       'dhcp6': False,
-                      'match': {'macaddress': mac.lower()},
+                      'match': {'name': nic_name},
                       'set-name': nic_name}
         if nic_metadata.get('ipv6s'):  # Any IPv6 addresses configured
             dev_config['dhcp6'] = True

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -107,7 +107,7 @@ def _add_network_config_from_opc_imds(network_config):
             network_config['ethernets'][name] = {
                 'addresses': [vnic_dict['privateIp']],
                 'mtu': MTU, 'dhcp4': False, 'dhcp6': False,
-                'match': {'macaddress': mac_address}}
+                'match': {'name': name}, 'set-name': name}
 
 
 def _ensure_netfailover_safe(network_config):

--- a/cloudinit/sources/tests/test_oracle.py
+++ b/cloudinit/sources/tests/test_oracle.py
@@ -581,7 +581,7 @@ class TestNetworkConfigFromOpcImds(test_helpers.CiTestCase):
         secondary_nic_cfg = network_config['ethernets']['ens3']
         self.assertFalse(secondary_nic_cfg['dhcp4'])
         self.assertFalse(secondary_nic_cfg['dhcp6'])
-        self.assertEqual(mac_addr, secondary_nic_cfg['match']['macaddress'])
+        self.assertEqual('ens3', secondary_nic_cfg['match']['name'])
         self.assertEqual(9000, secondary_nic_cfg['mtu'])
 
         self.assertEqual(1, len(secondary_nic_cfg['addresses']))

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -163,7 +163,7 @@ class TestParseNetworkConfig(CiTestCase):
             'eth0': {'dhcp4': True,
                      'dhcp4-overrides': {'route-metric': 100},
                      'dhcp6': False,
-                     'match': {'macaddress': '00:0d:3a:04:75:98'},
+                     'match': {'name': 'eth0'},
                      'set-name': 'eth0'}}, 'version': 2}
         self.assertEqual(expected, dsaz.parse_network_config(NETWORK_METADATA))
 
@@ -173,15 +173,15 @@ class TestParseNetworkConfig(CiTestCase):
             'eth0': {'dhcp4': True,
                      'dhcp4-overrides': {'route-metric': 100},
                      'dhcp6': False,
-                     'match': {'macaddress': '00:0d:3a:04:75:98'},
+                     'match': {'name': 'eth0'},
                      'set-name': 'eth0'},
             'eth1': {'set-name': 'eth1',
-                     'match': {'macaddress': '22:0d:3a:04:75:98'},
+                     'match': {'name': 'eth1'},
                      'dhcp6': False,
                      'dhcp4': True,
                      'dhcp4-overrides': {'route-metric': 200}},
             'eth2': {'set-name': 'eth2',
-                     'match': {'macaddress': '33:0d:3a:04:75:98'},
+                     'match': {'name': 'eth2'},
                      'dhcp6': False,
                      'dhcp4': True,
                      'dhcp4-overrides': {'route-metric': 300}}}, 'version': 2}
@@ -202,15 +202,15 @@ class TestParseNetworkConfig(CiTestCase):
                      'dhcp4-overrides': {'route-metric': 100},
                      'dhcp6': True,
                      'dhcp6-overrides': {'route-metric': 100},
-                     'match': {'macaddress': '00:0d:3a:04:75:98'},
+                     'match': {'name': 'eth0'},
                      'set-name': 'eth0'},
             'eth1': {'set-name': 'eth1',
-                     'match': {'macaddress': '22:0d:3a:04:75:98'},
+                     'match': {'name': 'eth1'},
                      'dhcp4': True,
                      'dhcp6': False,
                      'dhcp4-overrides': {'route-metric': 200}},
             'eth2': {'set-name': 'eth2',
-                     'match': {'macaddress': '33:0d:3a:04:75:98'},
+                     'match': {'name': 'eth2'},
                      'dhcp4': True,
                      'dhcp4-overrides': {'route-metric': 300},
                      'dhcp6': True,
@@ -244,7 +244,7 @@ class TestParseNetworkConfig(CiTestCase):
                      'dhcp4-overrides': {'route-metric': 100},
                      'dhcp6': True,
                      'dhcp6-overrides': {'route-metric': 100},
-                     'match': {'macaddress': '00:0d:3a:04:75:98'},
+                     'match': {'name': 'eth0'},
                      'set-name': 'eth0'}}, 'version': 2}
         imds_data = copy.deepcopy(NETWORK_METADATA)
         nic1 = imds_data['network']['interface'][0]
@@ -264,7 +264,7 @@ class TestParseNetworkConfig(CiTestCase):
                      'dhcp4-overrides': {'route-metric': 100},
                      'dhcp6': True,
                      'dhcp6-overrides': {'route-metric': 100},
-                     'match': {'macaddress': '00:0d:3a:04:75:98'},
+                     'match': {'name': 'eth0'},
                      'set-name': 'eth0'}}, 'version': 2}
         imds_data = copy.deepcopy(NETWORK_METADATA)
         nic1 = imds_data['network']['interface'][0]
@@ -764,7 +764,7 @@ scbus-1 on xpt0 bus 0
         expected_network_config = {
             'ethernets': {
                 'eth0': {'set-name': 'eth0',
-                         'match': {'macaddress': '00:0d:3a:04:75:98'},
+                         'match': {'name': 'eth0'},
                          'dhcp6': False,
                          'dhcp4': True,
                          'dhcp4-overrides': {'route-metric': 100}}},
@@ -782,17 +782,17 @@ scbus-1 on xpt0 bus 0
         expected_network_config = {
             'ethernets': {
                 'eth0': {'set-name': 'eth0',
-                         'match': {'macaddress': '00:0d:3a:04:75:98'},
+                         'match': {'name': 'eth0'},
                          'dhcp6': False,
                          'dhcp4': True,
                          'dhcp4-overrides': {'route-metric': 100}},
                 'eth1': {'set-name': 'eth1',
-                         'match': {'macaddress': '22:0d:3a:04:75:98'},
+                         'match': {'name': 'eth1'},
                          'dhcp6': False,
                          'dhcp4': True,
                          'dhcp4-overrides': {'route-metric': 200}},
                 'eth2': {'set-name': 'eth2',
-                         'match': {'macaddress': '33:0d:3a:04:75:98'},
+                         'match': {'name': 'eth2'},
                          'dhcp6': False,
                          'dhcp4': True,
                          'dhcp4-overrides': {'route-metric': 300}}},
@@ -1146,7 +1146,7 @@ scbus-1 on xpt0 bus 0
                 'eth0': {'dhcp4': True,
                          'dhcp4-overrides': {'route-metric': 100},
                          'dhcp6': False,
-                         'match': {'macaddress': '00:0d:3a:04:75:98'},
+                         'match': {'name': 'eth0'},
                          'set-name': 'eth0'}},
             'version': 2}
 

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -398,7 +398,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
 
         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': '06:17:04:d7:26:09'}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp6': True}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
@@ -427,7 +427,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
 
         mac1 = '06:17:04:d7:26:08'  # IPv4 only in DEFAULT_METADATA
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': mac1.lower()}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp6': False}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
@@ -463,7 +463,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
 
         mac1 = '0a:07:84:3d:6e:38'  # 1 secondary IPv4 and 2 secondary IPv6
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': mac1}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'addresses': ['172.31.45.70/20',
                           '2600:1f16:292:100:f152:2222:3333:4444/128',
                           '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
@@ -515,7 +515,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
             'Refreshing stale metadata from prior to upgrade',
             self.logs.getvalue())
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': mac1}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(expected, ds.network_config)
 
@@ -814,7 +814,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
 
         # DE:AD:BE:EF:FF:FF represented by OS but not in metadata
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
@@ -830,7 +830,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         nic1_metadata.pop('public-ipv4s')
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
@@ -846,7 +846,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['local-ipv4s'] = '172.3.3.15'
         nic1_metadata.pop('public-ipv4s')
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
@@ -863,7 +863,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
 
         # When no ipv4 or ipv6 content but fallback_nic set, set dhcp4 config.
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
@@ -880,7 +880,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata.pop('public-ipv4s')
         nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
@@ -901,11 +901,11 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
         expected = {'version': 2, 'ethernets': {
             'eth9': {
-                'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+                'match': {'name': 'eth9'}, 'set-name': 'eth9',
                 'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
                 'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}},
             'eth10': {
-                'match': {'macaddress': mac2}, 'set-name': 'eth10',
+                'match': {'name': 'eth10'}, 'set-name': 'eth10',
                 'dhcp4': True, 'dhcp4-overrides': {'route-metric': 200},
                 'dhcp6': False}}}
         self.assertEqual(
@@ -921,7 +921,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
             network_metadata_both['interfaces']['macs'][self.mac1])
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'match': {'name': 'eth9'}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
@@ -931,7 +931,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
     def test_convert_ec2_metadata_gets_macs_from_get_interfaces_by_mac(self):
         """Convert Ec2 Metadata calls get_interfaces_by_mac by default."""
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1},
+            'match': {'name': 'eth9'},
             'set-name': 'eth9', 'dhcp4': True, 'dhcp6': False}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:


### PR DESCRIPTION
The prior commit 271b349 appears to only work on ESX based DE due to the
fact that we don't use any cloud datasource when running on that
platform. This change attempts to extend that same change, but to work
properly on the Azure, Ec2, and Oracle cloud platforms.