### PR TITLE
Fix test bug in cloud-init

### DIFF
--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -288,7 +288,7 @@ class TestParseNetworkConfig(CiTestCase):
                 'dhcp4-overrides': {'route-metric': 100},
                 'dhcp6': False,
                 'match': {
-                    'macaddress': '00:0d:3a:04:75:98',
+                    'name': 'eth0',
                     'driver': 'hv_netvsc',
                 },
                 'set-name': 'eth0'


### PR DESCRIPTION
Ran package built to do tests manually: 
```
tests/unittests/test_datasource/test_azure.py::TestParseNetworkConfig::test_match_driver_for_netvsc PASSED [ 24%]
```
And ab-pre-push in progress http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4093/