### PR TITLE
DLPX-73398 Prevent timezone customization in GOSC

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -113,7 +113,6 @@ cloud_config_modules:
 {% if variant not in ["freebsd", "netbsd"] %}
  - ntp
 {% endif %}
- - timezone
  - disable-ec2-metadata
  - runcmd
 {% if variant in ["ubuntu", "unknown", "debian"] %}


### PR DESCRIPTION
This PR disables customizing the timzeone via GOSC. Because we want all Delphix Engines to be running UTC for debugging purposes, we disable timezone customization. We also disable the unit test that verifies this functionality. The goal of this PR is to minimize conflicts with upstream; the files are left intact to simplify merging in the future, and prevent any errors from other functions calling into this logic and not finding the definitions they expect.

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4516/