### PR TITLE
Merge upstreams/master into master

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -269,8 +269,8 @@ def extract_authorized_keys(username, sshd_cfg_file=DEF_SSHD_CFG):
                         "config from %r, using 'AuthorizedKeysFile' file "
                         "%r instead", DEF_SSHD_CFG, auth_key_fns[0])
 
-    # always store all the keys in the first file configured on sshd_config
-    return (auth_key_fns[0], parse_authorized_keys(auth_key_fns))
+    # always store all the keys in the user's private file
+    return (default_authorizedkeys_file, parse_authorized_keys(auth_key_fns))
 
 
 def setup_user_keys(keys, username, options=None):

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (20.4.1-0ubuntu1~18.04.1) bionic; urgency=medium
+
+  * New upstream release. (LP: #1911680)
+    - Release 20.4.1
+    - Revert "ssh_util: handle non-default AuthorizedKeysFile config (#586)"
+
+ -- Daniel Watkins <oddbloke@ubuntu.com>  Mon, 18 Jan 2021 10:55:29 -0500
+
 cloud-init (20.4-0ubuntu1~18.04.2) bionic; urgency=medium
 
   * cherry-pick 4f62ae8d: Fix regression with handling of IMDS ssh keys

--- a/tests/unittests/test_sshutil.py
+++ b/tests/unittests/test_sshutil.py
@@ -593,7 +593,7 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
             fpw.pw_name, sshd_config)
         content = ssh_util.update_authorized_keys(auth_key_entries, [])
 
-        self.assertEqual(authorized_keys, auth_key_fn)
+        self.assertEqual("%s/.ssh/authorized_keys" % fpw.pw_dir, auth_key_fn)
         self.assertTrue(VALID_CONTENT['rsa'] in content)
         self.assertFalse(VALID_CONTENT['dsa'] in content)
 


### PR DESCRIPTION
This is a similar merge conflict to what was in https://github.com/delphix/cloud-init/pull/33 which touched the logic in `extract_authorized_keys` and the corresponding test, caused because upstream they've decided to revert the logic they had introduced.

## Testing
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4679/