### PR TITLE
DLPX-73978 [Backport of DLPX-73969 to 6.0.6.1] Disable users-groups cloud-init module

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -78,7 +78,6 @@ cloud_init_modules:
  - ca-certs
  - rsyslog
 {% endif %}
- - users-groups
  - ssh
 
 # The modules that run in the 'config' stage


### PR DESCRIPTION
clean cherry-pick of #35

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4693/