### PR TITLE
DLPX-74001 Disable set-passwords and ssh-authkey-fingerprints cloud-init modules

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -90,7 +90,6 @@ cloud_config_modules:
 {% endif %}
  - ssh-import-id
  - locale
- - set-passwords
 {% if variant in ["rhel", "fedora"] %}
  - spacewalk
  - yum-add-repo
@@ -141,7 +140,6 @@ cloud_final_modules:
  - scripts-per-boot
  - scripts-per-instance
  - scripts-user
- - ssh-authkey-fingerprints
  - keys-to-console
  - phone-home
  - final-message


### PR DESCRIPTION
This is a follow-up to #35

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4695/
- Manually tested on 6.0.6.1