### PR TITLE
DLPX-74002 [Backport of DLPX-74001 to 6.0.6.1] Disable set-passwordsand ssh-authkey-fingerprints cloud-init modules

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -90,7 +90,6 @@ cloud_config_modules:
 {% endif %}
  - ssh-import-id
  - locale
- - set-passwords
 {% if variant in ["rhel", "fedora"] %}
  - spacewalk
  - yum-add-repo
@@ -140,7 +139,6 @@ cloud_final_modules:
  - scripts-per-boot
  - scripts-per-instance
  - scripts-user
- - ssh-authkey-fingerprints
  - keys-to-console
  - phone-home
  - final-message


### PR DESCRIPTION
Clean cherry-pick of #37 

## Testing
- ab-pre-push: http://ops.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/707
- Checked manually that no cloud-init services fail on Azure