### PR TITLE
TOOL-17693  cloud-init's DHCP unit tests need root

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,7 +10,7 @@ export PYBUILD_INSTALL_ARGS=--init-system=$(INIT_SYSTEM)
 
 override_dh_auto_test:
 ifeq (,$(findstring nocheck,$(DEB_BUILD_OPTIONS)))
-	http_proxy= make PYVER=python3 check
+	sudo http_proxy= make PYVER=python3 check
 else
 	@echo check disabled by DEB_BUILD_OPTIONS=$(DEB_BUILD_OPTIONS)
 endif


### PR DESCRIPTION
This change is needed to build on a Delphix engine.