### PR TITLE
TOOL-18684   Revert cloud-init service commits

### DIFF
--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -4,11 +4,11 @@ Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
 After=snapd.seeded.service
 Wants=network-online.target cloud-config.target
-ConditionVirtualization=!container
 {% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled
 {% endif %}
+ConditionalVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -8,7 +8,6 @@ Wants=network-online.target cloud-config.target
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled
 {% endif %}
-ConditionalVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -7,11 +7,11 @@ After=multi-user.target
 Before=apt-daily.service
 {% endif %}
 Wants=network-online.target cloud-config.service
-ConditionVirtualization=!container
 {% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled
 {% endif %}
+ConditionalVirtualization=!container
 
 
 [Service]

--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -11,7 +11,6 @@ Wants=network-online.target cloud-config.service
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled
 {% endif %}
-ConditionalVirtualization=!container
 
 
 [Service]

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -26,7 +26,6 @@ Before=sysinit.target
 Conflicts=shutdown.target
 {% endif %}
 RequiresMountsFor=/var/lib/cloud
-ConditionVirtualization=!container
 {% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -32,7 +32,6 @@ Before=shutdown.target
 Conflicts=shutdown.target
 {% endif %}
 Before=systemd-user-sessions.service
-ConditionVirtualization=!container
 {% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -4,7 +4,6 @@ Description=Initial cloud-init job (metadata service crawler)
 {% if variant not in ["photon", "rhel"] %}
 DefaultDependencies=no
 {% endif %}
-After=local-fs.target
 Wants=cloud-init-local.service
 After=cloud-init-local.service
 After=systemd-networkd-wait-online.service

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -7,7 +7,6 @@ DefaultDependencies=no
 Wants=cloud-init-local.service
 After=cloud-init-local.service
 After=systemd-networkd-wait-online.service
-After=nss-lookup.target
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 After=networking.service
 {% endif %}


### PR DESCRIPTION
This PR reverts the following commits and their respective functionality has been moved to `delphix-platform`:
```
commit 686c315ebd62d51727005b1bea4ea0af6775ac7f
Author: George Wilson <george.wilson@delphix.com>
Date:   Fri Jan 13 16:38:21 2023 -0500

    Revert "DLPX-70169 cloud-init and related services need override.conf to prevent them from running within upgrade container (#15)"

    This reverts commit 61f2f79274966a1b5cbe9c0e63afcf48d73b7e53.

commit abaecf4bdd02bb58380940e6b9965907ac134fb5
Author: George Wilson <george.wilson@delphix.com>
Date:   Fri Jan 13 16:35:02 2023 -0500

    Revert "Fix uses of "ConditionalVirtualization" (#17)"

    This reverts commit c5b5ab9ebb6a269c4ea759a43e820d61d2cc33ac.

commit f1a96a70a82943c0ec311ca29e093c80b0d866da
Author: George Wilson <george.wilson@delphix.com>
Date:   Fri Jan 13 16:25:50 2023 -0500

    Revert "DLPX-64359 GCP fails to query instance metadata"

    This reverts commit 1042b8301c70c3081b45606f9e84f76cde7464b6.

commit 1ca8a8a7364141adf6b5eff4e26ebd8daad3e9c4
Author: George Wilson <george.wilson@delphix.com>
Date:   Fri Jan 13 16:24:43 2023 -0500

    Revert "Add "local-fs.target" dependency to "cloud-init.service""

    This reverts commit dfb58ea95fb1bdfe872df81ad627c64de0d47ad4.
```