### PR TITLE
DLPX-85019 DE version 8.0.0 - Management service fails to start when …

### DIFF
--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -101,6 +101,8 @@ def handle(
         cloud.distro.set_option("prefer_fqdn_over_hostname", hostname_fqdn)
 
     (hostname, fqdn, is_default) = util.get_hostname_fqdn(cfg, cloud)
+    if fqdn[-1] == '.':
+        fqdn = fqdn[:-1]
     if is_default and hostname == "localhost":
         # https://github.com/systemd/systemd/commit/d39079fcaa05e23540d2b1f0270fa31c22a7e9f1
         log.debug("Hostname is localhost. Let other services handle this.")


### PR DESCRIPTION
…FQDN ends with a dot.

We apply the fix to the other hostname-setting API. It's still not clear to me why one API is used over the other (or even really why two exist), but applying the fix to both should resolve the issue.  I'll also start preparing a hotfix with this for 8.0.0.0.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/4708/