### PR TITLE
DLPX-85079 Backport FQDN trailing dot fix into 9.0

### DIFF
--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -101,6 +101,8 @@ def handle(
         cloud.distro.set_option("prefer_fqdn_over_hostname", hostname_fqdn)
 
     (hostname, fqdn, is_default) = util.get_hostname_fqdn(cfg, cloud)
+    if fqdn[-1] == '.':
+        fqdn = fqdn[:-1]
     if is_default and hostname == "localhost":
         # https://github.com/systemd/systemd/commit/d39079fcaa05e23540d2b1f0270fa31c22a7e9f1
         log.debug("Hostname is localhost. Let other services handle this.")


### PR DESCRIPTION
This PR is a backport of the new FQDN change into release so we can integrated into 9.0. This is necessary to unblock the customer, who would like to deploy ASAP but needs this fix in a released version in order to do so without support intervention.

Manually tested using the same procedure from the original PR.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/4732/console