### PR TITLE
DLPX-85109 Handle commas and other bad characters in FQDN

### DIFF
--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -97,8 +97,6 @@ def handle(
         cloud.distro.set_option("prefer_fqdn_over_hostname", hostname_fqdn)
 
     (hostname, fqdn, is_default) = util.get_hostname_fqdn(cfg, cloud)
-    if fqdn[-1] == '.':
-        fqdn = fqdn[:-1]
     # Check for previous successful invocation of set-hostname
 
     # set-hostname artifact file accounts for both hostname and fqdn

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -101,8 +101,6 @@ def handle(
         cloud.distro.set_option("prefer_fqdn_over_hostname", hostname_fqdn)
 
     (hostname, fqdn, is_default) = util.get_hostname_fqdn(cfg, cloud)
-    if fqdn[-1] == '.':
-        fqdn = fqdn[:-1]
     if is_default and hostname == "localhost":
         # https://github.com/systemd/systemd/commit/d39079fcaa05e23540d2b1f0270fa31c22a7e9f1
         log.debug("Hostname is localhost. Let other services handle this.")

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1135,6 +1135,19 @@ def dos2unix(contents):
     return contents.replace("\r\n", "\n")
 
 
+def sanitize_fqdn(fqdn):
+    output = ''
+    allowed = re.compile('[a-zA-Z0-9.-]')
+    for character in fqdn:
+        if allowed.match(character):
+            output = output + character
+            continue
+        output = output + str(ord(character))
+    if output[-1] == '.':
+        output = output[:-1]
+    return output
+
+
 HostnameFqdnInfo = namedtuple(
     "HostnameFqdnInfo",
     ["hostname", "fqdn", "is_default"],
@@ -1181,6 +1194,8 @@ def get_hostname_fqdn(cfg, cloud, metadata_only=False):
                 hostname, is_default = cloud.get_hostname(
                     metadata_only=metadata_only
                 )
+    if fqdn is not None:
+        fqdn = sanitize_fqdn(fqdn)
     return HostnameFqdnInfo(hostname, fqdn, is_default)
 
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1135,6 +1135,12 @@ def dos2unix(contents):
     return contents.replace("\r\n", "\n")
 
 
+# We have this function to help deal with problematic FQDNs. Some customers
+# put unsupported or unnecessary things in their DNS domain names, and these
+# can cause problems for the tooling on the Delphix Engine. This function
+# attempts to replace any invalid characters with their integer ascii
+# representation, and removes trailing dots from domain names, two issues
+# we've encountered.
 def sanitize_fqdn(fqdn):
     output = ''
     allowed = re.compile('[a-zA-Z0-9.-]')


### PR DESCRIPTION
This PR refines and streamlines the changes that were made in the dot-terminal FQDN issue with the changes necessary to handle this issue. It also applies those changes to all users of the get_hostname_fqdn API, instead of just two.

Tested using automated tests http://selfservice.jenkins.delphix.com/job/appliance-build-stage0/job/pre-push/4161/console

AMI was copied into an AWS account where two anomalous VPCs had been configured. One has a dot-terminal DNS Domain Name, and the other has a DNS Domain Name with a comma and a space separating options. 
On a normal 10.0 VM, the FQDN looks like this: `ip-10-0-0-181.pcd.net,pcd2.net`, and the app-stack failed to start.
With the modifications, it instead looks like `ip-10-0-0-146.pcd.net44pcd2.net`, and the app-stack started successfully.
Also tested with dot-terminated domain names.