### PR TITLE
HF-1246 Handle commas and other bad characters in FQDN

### DIFF
--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -97,8 +97,6 @@ def handle(
         cloud.distro.set_option("prefer_fqdn_over_hostname", hostname_fqdn)
 
     (hostname, fqdn, is_default) = util.get_hostname_fqdn(cfg, cloud)
-    if fqdn[-1] == '.':
-        fqdn = fqdn[:-1]
     # Check for previous successful invocation of set-hostname
 
     # set-hostname artifact file accounts for both hostname and fqdn

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -101,8 +101,6 @@ def handle(
         cloud.distro.set_option("prefer_fqdn_over_hostname", hostname_fqdn)
 
     (hostname, fqdn, is_default) = util.get_hostname_fqdn(cfg, cloud)
-    if fqdn[-1] == '.':
-        fqdn = fqdn[:-1]
     if is_default and hostname == "localhost":
         # https://github.com/systemd/systemd/commit/d39079fcaa05e23540d2b1f0270fa31c22a7e9f1
         log.debug("Hostname is localhost. Let other services handle this.")

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1135,6 +1135,19 @@ def dos2unix(contents):
     return contents.replace("\r\n", "\n")
 
 
+def sanitize_fqdn(fqdn):
+    output = ''
+    allowed = re.compile('[a-zA-Z0-9.-]')
+    for character in fqdn:
+        if allowed.match(character):
+            output = output + character
+            continue
+        output = output + str(ord(character))
+    if output[-1] == '.':
+        output = output[:-1]
+    return output
+
+
 HostnameFqdnInfo = namedtuple(
     "HostnameFqdnInfo",
     ["hostname", "fqdn", "is_default"],
@@ -1181,6 +1194,8 @@ def get_hostname_fqdn(cfg, cloud, metadata_only=False):
                 hostname, is_default = cloud.get_hostname(
                     metadata_only=metadata_only
                 )
+    if fqdn is not None:
+        fqdn = sanitize_fqdn(fqdn)
     return HostnameFqdnInfo(hostname, fqdn, is_default)
 
 


### PR DESCRIPTION
Same as #72 , but hotfixified. Tested by converting the hotfix VMDK generated by the modified hotfix-build process into an AMI, and deploying it on the VPCs with troublesome DHCP option sets. The app-stack came up as expected in both cases, and the VMs correctly reported their delphix version (9.0) and hotfix ID.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/4844/