### PR TITLE
DLPX-91506 failed to update the networkInterface MTU value on ESX platform

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -573,7 +573,6 @@ def generate_fallback_config(config_driver=None):
 
     cfg = {
         "dhcp4": True,
-        "dhcp6": True,
         "set-name": target_name,
         "match": match,
     }

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -264,7 +264,6 @@ class TestGenerateFallbackConfig(CiTestCase):
                 "eth1": {
                     "match": {"name": "eth1"},
                     "dhcp4": True,
-                    "dhcp6": True,
                     "set-name": "eth1",
                 }
             },
@@ -282,7 +281,6 @@ class TestGenerateFallbackConfig(CiTestCase):
                 "eth0": {
                     "match": {"name": "eth0"},
                     "dhcp4": True,
-                    "dhcp6": True,
                     "set-name": "eth0",
                 }
             },
@@ -298,7 +296,6 @@ class TestGenerateFallbackConfig(CiTestCase):
             "ethernets": {
                 "eth0": {
                     "dhcp4": True,
-                    "dhcp6": True,
                     "match": {"name": "eth0"},
                     "set-name": "eth0",
                 }
@@ -365,7 +362,6 @@ class TestGenerateFallbackConfig(CiTestCase):
             "ethernets": {
                 "ens3": {
                     "dhcp4": True,
-                    "dhcp6": True,
                     "match": {"name": "ens3"},
                     "set-name": "ens3",
                 }

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4826,7 +4826,6 @@ class TestGenerateFallbackConfig(CiTestCase):
             "ethernets": {
                 "eth0": {
                     "dhcp4": True,
-                    "dhcp6": True,
                     "set-name": "eth0",
                     "match": {
                         "name": "eth0",
@@ -4911,9 +4910,6 @@ iface lo inet loopback
 
 auto eth0
 iface eth0 inet dhcp
-
-# control-alias eth0
-iface eth0 inet6 dhcp
 """
         self.assertEqual(expected.lstrip(), contents.lstrip())
 
@@ -4996,9 +4992,6 @@ iface lo inet loopback
 
 auto eth1
 iface eth1 inet dhcp
-
-# control-alias eth1
-iface eth1 inet6 dhcp
 """
         self.assertEqual(expected.lstrip(), contents.lstrip())
 
@@ -5215,8 +5208,6 @@ class TestRhelSysConfigRendering(CiTestCase):
 #
 BOOTPROTO=dhcp
 DEVICE=eth1000
-DHCPV6C=yes
-IPV6INIT=yes
 NM_CONTROLLED=no
 ONBOOT=yes
 TYPE=Ethernet
@@ -6140,8 +6131,7 @@ class TestOpenSuseSysConfigRendering(CiTestCase):
             expected_content = """
 # Created by cloud-init automatically, do not edit.
 #
-BOOTPROTO=dhcp
-DHCLIENT6_MODE=managed
+BOOTPROTO=dhcp4
 STARTMODE=auto
 """.lstrip()
             self.assertEqual(expected_content, content)
@@ -6539,12 +6529,8 @@ class TestNetworkManagerRendering(CiTestCase):
 
                 [ipv4]
                 method=auto
-                may-fail=true
-
-                [ipv6]
-                method=auto
-                may-fail=true
-
+                may-fail=false
+                
                 """
                 ),
             },
@@ -6851,9 +6837,6 @@ iface lo inet loopback
 
 auto eth1000
 iface eth1000 inet dhcp
-
-# control-alias eth1000
-iface eth1000 inet6 dhcp
 """
         self.assertEqual(expected.lstrip(), contents.lstrip())
 
@@ -6913,7 +6896,6 @@ class TestNetplanNetRendering:
                   ethernets:
                     eth1000:
                       dhcp4: true
-                      dhcp6: true
                       match:
                         name: eth1000
                       set-name: eth1000
@@ -8441,7 +8423,7 @@ class TestNetworkdNetRendering(CiTestCase):
             [Match]
             Name=eth1000
             [Network]
-            DHCP=yes"""
+            DHCP=ipv4"""
         ).rstrip(" ")
 
         expected = self.create_conf_dict(expected.splitlines())

--- a/tools/read-version
+++ b/tools/read-version
@@ -83,6 +83,7 @@ def get_version_from_git(
                 "describe",
                 branch_name,
                 "--abbrev=8",
+                "--tags",
             ] + flags
 
             try:
@@ -101,7 +102,7 @@ def get_version_from_git(
     else:
         version = src_version
         version_long = ""
-    return version, version_long
+    return os.path.basename(version), os.path.basename(version_long)
 
 
 def main(use_tags: bool = False, output_json: bool = False):


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

A recent upstream change - https://github.com/canonical/cloud-init/commit/0264e969166846b2f5cf87ccdb051a3a795eca15 enabled the configuration directive that enables DHCP for IPv6 by default. This landed in our fork via [this PR](https://github.com/delphix/cloud-init/pull/86) and was first introduced in 24.0. 
This is now causing failures when configuring NICs via the app-stack because the app-stack assumes that only DHCP for IPv4 is enabled. The stack only supplies DHCP overrides for IPv4. Per [Netplan's documentation](https://netplan.readthedocs.io/en/latest/netplan-yaml/#dhcp-overrides)
> If both dhcp4 and dhcp6 are true, the networkd back end requires that dhcp4-overrides and dhcp6-overrides contain the same keys and values. If the values do not match, an error will be shown and the network configuration will not be applied.

And thus, we see failures like these:
```
Caused by: com.delphix.misc.osadmin.util.OsAdminUtils$NonZeroExitException: An error occured during the execution of netplan. arguments: [netplan,generate], output: [[ERROR: ens192: networkd requires that use-mtu has the same value in both dhcp4_overrides and dhcp6_overrides, ]], Exit Code: 1 [exitCode: 1]
```
This bug exists in versions >=24.0. This has already resulted in an [escalation](https://delphix.atlassian.net/browse/ESCL-5015) and some Blackbox network tests are failing due to this too.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Disable DHCP for IPv6 altogether from our fork of cloud-init. While we could have our stack disable it, or provide an override via delphix-platform, I figured it's best to disable it via cloud-init directly.
</details>

<details open>
<summary><h2> Notes to Reviewers </h2></summary>

See screenshots in the escalation ticket - [ESCL-5015](https://delphix.atlassian.net/browse/ESCL-5015)
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

- ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8818/

- Run the failing blackbox test against an engine with the fix (In progress) - http://selfservice.jenkins.delphix.com/job/blackbox-self-service/139794/consoleFull

- Test the escalation scenario. Deploy an engine via an OVA and connect it to a network without a DHCP server, configure the network to verify that it succeeds.
<img width="1728" alt="Screenshot 2024-07-02 at 9 27 47 AM" src="https://github.com/delphix/cloud-init/assets/87093175/b2c4e0d7-eb45-4363-b8bd-4467ab6bab86">
<img width="1728" alt="Screenshot 2024-07-02 at 9 28 36 AM" src="https://github.com/delphix/cloud-init/assets/87093175/6874fdbb-46e3-474b-a142-24dad5570176">
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
