### PR TITLE
DLPX-93024 24.04: cloud-init fails due to incorrect module call

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -212,7 +212,7 @@ class DataSourceNoCloud(sources.DataSource):
         # to accomplish this.
         system_uuid = None
         try:
-            system_uuid = util.read_dmi_data('system-uuid')
+            system_uuid = dmi.read_dmi_data('system-uuid')
             system_uuid = system_uuid.lower() if system_uuid else None
         except Exception:
             util.logexc(LOG, "Failed to get system uuid from dmi")


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

`cloud-init` failed on a 24.04 appliance because of a function call from the wrong module.
The `read_dmi_data` function exists in `dmi.py` and not in `util.py`.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Use the correct module.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

appliance-build: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/job/os-upgrade/job/pre-push/83/console
pg-os-upgrade.dcol2.delphix.com: 
```
delphix@localhost:~$ sudo tail -f /var/log/cloud-init.log
sudo: unable to resolve host localhost.localdomain: Name or service not known
2025-01-08 02:10:31,754 - main.py[DEBUG]: Ran 7 modules with 0 failures
2025-01-08 02:10:31,754 - util.py[DEBUG]: Reading from /proc/uptime (quiet=False)
2025-01-08 02:10:31,755 - util.py[DEBUG]: Read 12 bytes from /proc/uptime
2025-01-08 02:10:31,755 - atomic_helper.py[DEBUG]: Atomically writing to file /var/lib/cloud/data/status.json (via temporary file /var/lib/cloud/data/tmp665tf6u0) - w: [644] 541 bytes/chars
2025-01-08 02:10:31,756 - atomic_helper.py[DEBUG]: Atomically writing to file /var/lib/cloud/data/result.json (via temporary file /var/lib/cloud/data/tmp1jthhq31) - w: [644] 103 bytes/chars
2025-01-08 02:10:31,756 - util.py[DEBUG]: Creating symbolic link from '/run/cloud-init/result.json' => '../../var/lib/cloud/data/result.json'
2025-01-08 02:10:31,756 - util.py[DEBUG]: Reading from /proc/uptime (quiet=False)
2025-01-08 02:10:31,756 - util.py[DEBUG]: Read 12 bytes from /proc/uptime
2025-01-08 02:10:31,756 - util.py[DEBUG]: cloud-init mode 'modules' took 0.308 seconds (0.30)
2025-01-08 02:10:31,756 - handlers.py[DEBUG]: finish: modules-final: SUCCESS: running modules for final
^C
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
