### PR TITLE
DLPX-95748 cloud-init oracle data source needs to handle a null metadata value

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -252,7 +252,7 @@ class DataSourceOracle(sources.DataSource):
             "name": data["displayName"],
         }
 
-        if "metadata" in data:
+        if "metadata" in data and data["metadata"] is not None:
             user_data = data["metadata"].get("user_data")
             if user_data:
                 self.userdata_raw = base64.b64decode(user_data)


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
We've seen the "metadata" value exist but have a "null" value, which the cloud-init code doesn't handle.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Fix the logic to properly handle a "null" value (i.e. treat it the same as if the field doesn't exist).
</details>
